### PR TITLE
Add module documentation and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Testing Codex
+
+Simple Flask application with authentication and orders example.
+
+## Requirements
+
+- Python 3.8+
+- [Flask](https://flask.palletsprojects.com/)
+
+## Running the application
+
+Install the dependencies and run the `run.py` module:
+
+```bash
+pip install Flask
+python run.py
+```
+
+The server will start on `http://localhost:5000`. Access `/login` to log in.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,9 +1,13 @@
+"""Flask application factory and database initialization."""
+
 import sqlite3
 from pathlib import Path
 from flask import Flask
 
 
 def init_db(app: Flask) -> None:
+    """Create the SQLite database and seed it if it does not exist."""
+
     db_path = app.config['DATABASE']
     if not Path(db_path).exists():
         conn = sqlite3.connect(db_path)
@@ -36,6 +40,8 @@ def init_db(app: Flask) -> None:
 
 
 def create_app() -> Flask:
+    """Instantiate and configure the Flask application."""
+
     app = Flask(__name__, template_folder='../templates')
     app.config['SECRET_KEY'] = 'dev-secret-key'
     app.config['DATABASE'] = str(Path(app.root_path) / 'database.db')

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,3 +1,5 @@
+"""Routes and helper functions for the Flask application."""
+
 from flask import Blueprint, render_template, request, redirect, url_for, session, current_app
 import sqlite3
 
@@ -5,10 +7,17 @@ bp = Blueprint('main', __name__)
 
 
 def get_db():
+    """Return a connection object for the configured SQLite database."""
+
     return sqlite3.connect(current_app.config['DATABASE'])
 
 
 def check_login(username: str, password: str) -> bool:
+    """Validate user credentials and populate the session.
+
+    Returns ``True`` if the credentials match a user in the database.
+    """
+
     conn = get_db()
     cur = conn.cursor()
     cur.execute('SELECT id FROM users WHERE username=? AND password=?', (username, password))
@@ -22,6 +31,8 @@ def check_login(username: str, password: str) -> bool:
 
 
 def get_orders(user_id: int):
+    """Fetch a list of order items for the given user."""
+
     conn = get_db()
     cur = conn.cursor()
     cur.execute('SELECT item FROM orders WHERE user_id=?', (user_id,))
@@ -32,6 +43,8 @@ def get_orders(user_id: int):
 
 @bp.route('/login', methods=['GET', 'POST'])
 def login():
+    """Render the login form and authenticate the user."""
+
     error = None
     if request.method == 'POST':
         username = request.form['username']
@@ -44,6 +57,8 @@ def login():
 
 @bp.route('/dashboard')
 def dashboard():
+    """Show the dashboard for the logged in user."""
+
     if 'user_id' not in session:
         return redirect(url_for('main.login'))
     return render_template('dashboard.html', username=session.get('username'))
@@ -51,6 +66,8 @@ def dashboard():
 
 @bp.route('/pedidos')
 def pedidos():
+    """List the orders placed by the logged in user."""
+
     if 'user_id' not in session:
         return redirect(url_for('main.login'))
     orders = get_orders(session['user_id'])

--- a/main.py
+++ b/main.py
@@ -1,0 +1,1 @@
+"""Placeholder module for future command-line scripts."""

--- a/run.py
+++ b/run.py
@@ -1,3 +1,9 @@
+"""Application entry point.
+
+This module exposes a minimal runner to start the Flask application
+in development mode.
+"""
+
 from app import create_app
 
 app = create_app()


### PR DESCRIPTION
## Summary
- document modules with docstrings
- add entry point docstring for `run.py`
- document placeholder module `main.py`
- create a simple README with setup instructions

## Testing
- `python -m py_compile run.py app/__init__.py app/routes.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_684774237484832992f895c42f40494b